### PR TITLE
fix: Docker-compose is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,6 @@ grafana.ini:
 1. Clone the repository.
 2. Run `npm install` to install the dependencies.
 3. Run `npm run dev` to start development server.
-4. Run `docker-compose up` to start Grafana with the plugin.
+4. Run `docker compose up` to start Grafana with the plugin.
 5. Navigate to `http://localhost:3000/plugins/k8s-app` and configure the plugins datasource.
 6. Open Grafana at `http://localhost:3000/a/k8s-app/workloads`.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.0'
-
 services:
   grafana:
     container_name: 'k8s-app-11.0.0'


### PR DESCRIPTION
[Top level Version number](https://docs.docker.com/compose/compose-file/04-version-and-name/) in docker-compose.yaml is only a backwards compatibility thing now


Also `docker-compose` is deprecated and `docker compose` should be used instead.

