### PR TITLE
fix: Fix 'npm run server' to use 'docker compose' instead of docker-compose

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:fix": "npm run lint -- --fix",
     "e2e": "npm exec cypress install && npm exec grafana-e2e run",
     "e2e:update": "npm exec cypress install && npm exec grafana-e2e run --update-screenshots",
-    "server": "docker-compose up --build",
+    "server": "docker compose up --build",
     "sign": "npx --yes @grafana/sign-plugin@latest"
   },
   "author": "tiithansen",


### PR DESCRIPTION
README.md was already updated before to use `docker compose` instead of `docker-compose`, but package.json was not updated, giving problems when running `npm run server`.

 