### PR TITLE
Allow plugin id selection

### DIFF
--- a/src/common/variableHelpers.ts
+++ b/src/common/variableHelpers.ts
@@ -24,6 +24,7 @@ export interface TopLevelVariableSettings {
     defaultDatasource: string;
     defaultCluster?: string;
     clusterFilter?: string;
+    pluginId?: string;
 }
 
 export function createTopLevelVariables(props: JsonData, additionalVariables?: Array<SceneVariable<SceneVariableState>>) {
@@ -33,6 +34,7 @@ export function createTopLevelVariables(props: JsonData, additionalVariables?: A
         defaultDatasource: props.defaultDatasource || 'prometheus',
         defaultCluster: props.defaultCluster,
         clusterFilter: props.clusterFilter,
+        pluginId: props.pluginId,
     }
 
     return new SceneVariableSet({
@@ -40,7 +42,7 @@ export function createTopLevelVariables(props: JsonData, additionalVariables?: A
             new DataSourceVariable({
                 name: 'datasource',
                 label: 'Datasource',
-                pluginId: 'victoriametrics-metrics-datasource',
+                pluginId: settings.pluginId,
                 regex: settings.datasource,
                 value: settings.defaultDatasource,
             }),

--- a/src/common/variableHelpers.ts
+++ b/src/common/variableHelpers.ts
@@ -40,7 +40,7 @@ export function createTopLevelVariables(props: JsonData, additionalVariables?: A
             new DataSourceVariable({
                 name: 'datasource',
                 label: 'Datasource',
-                pluginId: 'prometheus',
+                pluginId: 'victoriametrics-metrics-datasource',
                 regex: settings.datasource,
                 value: settings.defaultDatasource,
             }),
@@ -59,8 +59,8 @@ export function createClusterVariable(defaultCluster?: string, clusterFilter?: s
             type: 'prometheus',
         },
         query: {
-          refId: 'cluster',
-          query: clusterFilter ? `label_values(${clusterFilter}, cluster)` : 'label_values(kube_namespace_status_phase, cluster)',
+            refId: 'cluster',
+            query: clusterFilter ? `label_values(${clusterFilter}, cluster)` : 'label_values(kube_namespace_status_phase, cluster)',
         },
         value: defaultCluster,
     })

--- a/src/components/AppConfig/AppConfig.tsx
+++ b/src/components/AppConfig/AppConfig.tsx
@@ -124,6 +124,7 @@ export type EventQuery = {
 export type JsonData = {
   datasource?: string;
   defaultDatasource?: string;
+  pluginId?: string;
   defaultCluster?: string;
   clusterFilter?: string;
   analyticsEnabled?: boolean;
@@ -138,6 +139,7 @@ type State = {
   // The regex pattern to match datasource
   datasource: string;
   defaultDatasource?: string;
+  pluginId?: string;
   defaultCluster?: string;
   clusterFilter?: string;
   prometheusDatasources?: Array<DataSourceInstanceSettings<DataSourceJsonData>>;
@@ -162,7 +164,7 @@ const DEFAULT_ANALYTIC_OPTIONS: AnalyticsOptions = {
   flatten: false,
 }
 
-interface Props extends PluginConfigPageProps<AppPluginMeta<JsonData>> {}
+interface Props extends PluginConfigPageProps<AppPluginMeta<JsonData>> { }
 
 export const AppConfig = ({ plugin }: Props) => {
   const s = useStyles2(getStyles);
@@ -170,6 +172,7 @@ export const AppConfig = ({ plugin }: Props) => {
   const [state, setState] = useState<State>({
     datasource: jsonData?.datasource || 'prometheus',
     defaultDatasource: jsonData?.defaultDatasource || '',
+    pluginId: jsonData?.pluginId || 'prometheus',
     defaultCluster: jsonData?.defaultCluster || '',
     clusterFilter: jsonData?.clusterFilter || '',
     analyticsEnabled: jsonData?.analyticsEnabled || false,
@@ -182,6 +185,13 @@ export const AppConfig = ({ plugin }: Props) => {
     eventQueries: jsonData?.eventQueries || createDefaultEventQueries(),
     logsEnabled: jsonData?.logsEnabled || false,
   });
+
+  const onChangePluginId = (event: ChangeEvent<HTMLInputElement>) => {
+    setState({
+      ...state,
+      pluginId: event.target.value,
+    });
+  };
 
   const onChangeDatasource = (event: ChangeEvent<HTMLInputElement>) => {
     setState({
@@ -324,7 +334,7 @@ export const AppConfig = ({ plugin }: Props) => {
 
     const lokiDatasources = getDataSourceSrv()
       .getList({ type: 'loki' });
-    
+
     const matchingNames: string[] = []
     prometheusDatasources.forEach((ds) => {
       if (ds.name.match(state.datasource)) {
@@ -348,6 +358,7 @@ export const AppConfig = ({ plugin }: Props) => {
         datasource: state.datasource,
         defaultDatasource: state.defaultDatasource,
         defaultCluster: state.defaultCluster,
+        pluginId: state.pluginId,
         clusterFilter: state.clusterFilter,
         analyticsEnabled: state.analyticsEnabled,
         analytics: state.analytics,
@@ -433,6 +444,16 @@ export const AppConfig = ({ plugin }: Props) => {
             onChange={onChangeDefaultDatasource}
           />
         </Field>
+        <Field label="Default pluginId" description="" className={s.marginTop}>
+          <Input
+            width={60}
+            id="pluginId"
+            label={`Name of the pluginId`}
+            value={state?.pluginId}
+            placeholder={`E.g.: prometheus`}
+            onChange={onChangePluginId}
+          />
+        </Field>
         <Field label="Default cluster" description="" className={s.marginTop}>
           <Input
             width={60}
@@ -455,7 +476,7 @@ export const AppConfig = ({ plugin }: Props) => {
         </Field>
       </FieldSet>
       <FieldSet label="Logs & Events settings" className={s.marginTopXl}>
-        <Alert  severity="warning" title="Ruler settings">
+        <Alert severity="warning" title="Ruler settings">
           <p>EXPERIMENTAL: Allows configuring Loki queries for pages.</p>
         </Alert>
         <Field label="Enable Logs & Events" description="Enable displaying of logs and events.">
@@ -466,7 +487,7 @@ export const AppConfig = ({ plugin }: Props) => {
           />
         </Field>
         <TabbedContainer
-          onClose={() => {}}
+          onClose={() => { }}
           tabs={[
             {
               label: 'Logs',
@@ -549,7 +570,7 @@ export const AppConfig = ({ plugin }: Props) => {
         </TabbedContainer>
       </FieldSet>
       <FieldSet label="Ruler settings" className={s.marginTopXl}>
-        <Alert  severity="warning" title="Ruler settings">
+        <Alert severity="warning" title="Ruler settings">
           <p>EXPERIMENTAL: Allows mapping clusters to rulers to fetch additional data for alerts from the rulers.</p>
         </Alert>
         <Button
@@ -593,7 +614,7 @@ export const AppConfig = ({ plugin }: Props) => {
         }
       </FieldSet>
       <FieldSet label="Analytics settings" className={s.marginTopXl}>
-        <Alert  severity="warning" title="Analytics settings">
+        <Alert severity="warning" title="Analytics settings">
           <p>EXPERIMENTAL: Analytics integration allows you to send data to an analytics server. This data can be used to monitor the plugin usage locally. No data will be sent to third parties.</p>
           <p>Original source code for analytics: <Link href="https://github.com/MacroPower/macropower-analytics-panel">MacroPower/macropower-analytics-panel</Link></p>
         </Alert>
@@ -617,15 +638,15 @@ export const AppConfig = ({ plugin }: Props) => {
         </Field>
       </FieldSet>
       <div className={s.marginTop}>
-          <Button
-            type="submit"
-            data-testid={testIds.appConfig.submit}
-            onClick={onSave}
-            disabled={Boolean(!state.datasource)}
-          >
-            Save
-          </Button>
-        </div>
+        <Button
+          type="submit"
+          data-testid={testIds.appConfig.submit}
+          onClick={onSave}
+          disabled={Boolean(!state.datasource)}
+        >
+          Save
+        </Button>
+      </div>
     </div>
   );
 };

--- a/src/components/AppConfig/AppConfig.tsx
+++ b/src/components/AppConfig/AppConfig.tsx
@@ -444,7 +444,7 @@ export const AppConfig = ({ plugin }: Props) => {
             onChange={onChangeDefaultDatasource}
           />
         </Field>
-        <Field label="Default pluginId" description="" className={s.marginTop}>
+        <Field label="Default pluginId" description="Allows changing the pluginId to support different datasource-plugins (eg: victoriametrics-metrics-datasource)" className={s.marginTop}>
           <Input
             width={60}
             id="pluginId"


### PR DESCRIPTION
hi,

ref: https://github.com/tiithansen/grafana-k8s-app/issues/134

while testing Grafana and this addon with [victoriametrics-metrics-datasource](https://github.com/VictoriaMetrics/victoriametrics-datasource) i noticed the hardcoded `pluginId` did prevent this addon from working.
Without much TS knowlege i was able to add the `pluginId` to the configuration page and it works as expected.

Not sure though about how/if to add tests for this. Feel free to close this if it is not suitable. ;)
